### PR TITLE
Branch v0.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@
 *.fasta
 *.fastq.gz
 *.fna.gz
+*.bt2
+01_simulation/mapped_reads/
 .snakemake/
+
 
 ### Base Python .gitignore
 # Byte-compiled / optimized / DLL files

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,201 @@
+### Custom
+*.fasta
+*.fastq.gz
+*.fna.gz
+.snakemake/
+
+### Base Python .gitignore
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Abstra
+# Abstra is an AI-powered process automation framework.
+# Ignore directories containing user credentials, local state, and settings.
+# Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  you could uncomment the following to ignore the enitre vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Cursor
+#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
+#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
+#  refer to https://docs.cursor.com/context/ignore-files
+.cursorignore
+.cursorindexingignore

--- a/01_simulation/01_simulation_create_reads.smk
+++ b/01_simulation/01_simulation_create_reads.smk
@@ -30,15 +30,6 @@ rule download_ref_genomes:
     shell:
         "wget {params.genome_url}/{params.genome_file} -O {output}"
 
-rule index_ref_genomes:
-    input:
-        ref=f"{ref_dir}/{genome_file}"
-    output:
-        f"{ref_dir}/{genome_file}"
-    conda: 
-        f"{main_dir}/envs/bowtie2_samtools.yaml"
-    shell: "bowtie2-build {input} {output}"
-
 rule create_ref_genomes_for_male_and_female:
     input:
         ref=f"{ref_dir}/{genome_file}"

--- a/01_simulation/01_simulation_create_reads.smk
+++ b/01_simulation/01_simulation_create_reads.smk
@@ -59,7 +59,7 @@ rule simulate_reads_male:
         f"{main_dir}/envs/wgsim-1.0.yaml"
     shell: 
         """
-        wgsim -N 100000000 -1 150 -2 150 {input} male_1.fastq male_2.fastq
+        wgsim -N 100000000 -1 150 -2 150 {input} male_1.fastq male_2.fastq > /dev/null
         gzip male_1.fastq male_2.fastq
         mv male_1.fastq.gz {output.fastq1}
         mv male_2.fastq.gz {output.fastq2}
@@ -74,7 +74,7 @@ rule simulate_reads_female:
         f"{main_dir}/envs/wgsim-1.0.yaml"
     shell:  
         """
-        wgsim -N 100000000 -1 150 -2 150 {input} female_1.fastq female_2.fastq
+        wgsim -N 100000000 -1 150 -2 150 {input} female_1.fastq female_2.fastq > /dev/null
         gzip female_1.fastq female_2.fastq
         mv female_1.fastq.gz {output.fastq1}
         mv female_2.fastq.gz {output.fastq2}

--- a/01_simulation/02_simulation_map_and_process_simulated_reads.smk
+++ b/01_simulation/02_simulation_map_and_process_simulated_reads.smk
@@ -17,11 +17,21 @@ rule all:
     input:
         expand(f"{map_dir}/S{{sex}}100000000.sorted.rmdup.bam", sex=["M", "F"])
 
+rule index_ref_genomes:
+    input:
+        ref=ref_genome_index
+    output:
+        index=ref_genome_index + ".1.bt2"
+    params: ref_genome_index
+    conda: 
+        f"{main_dir}/envs/bowtie2_samtools.yaml"
+    shell: "bowtie2-build {input} {params}"
+
 rule map_simulated_reads:
     input:
         forward_reads=f"{simulated_reads_dir}/S{{sex}}100000000_1.fastq.gz",
         reverse_reads=f"{simulated_reads_dir}/S{{sex}}100000000_2.fastq.gz",
-        index=ref_genome_index + ".bwt"
+        index=ref_genome_index + ".1.bt2"
     output:
         sorted_bam=f"{map_dir}/S{{sex}}100000000.sorted.bam"
     params:
@@ -30,9 +40,9 @@ rule map_simulated_reads:
         f"{main_dir}/envs/bowtie2_samtools.yaml"
     shell:
         """
-        bowtie2 -x {params.index} -1 {input.forward_reads} -2 {input.reverse_reads} | \
+        bowtie2 -p 5 -x {params.index} -1 {input.forward_reads} -2 {input.reverse_reads} | \
         samtools view -b -q 30 | \
-        samtools sort -o {output}
+        samtools sort  -@ 5 -m 1G -o {output}
         """
 
 rule add_read_groups:

--- a/envs/python3.9.yaml
+++ b/envs/python3.9.yaml
@@ -7,3 +7,4 @@ dependencies:
   - python=3.9
   - pysam
   - numpy
+  - biopython

--- a/scripts/create_ref.py
+++ b/scripts/create_ref.py
@@ -10,6 +10,7 @@ import os
 import sys
 import subprocess
 from Bio import SeqIO
+import gzip
 
 # Get command line arguments
 parser = argparse.ArgumentParser(description='Create reference genome for doing simulations for SCiMS')
@@ -28,22 +29,24 @@ args = parser.parse_args()
 # Put two copies of the reference genome in the output file except for 
 # the y chromosome
 with open(f"{args.output}_female.fasta", 'w') as out:
-    for record in SeqIO.parse(args.reference, 'fasta'):
-        if record.id != 'NC_000024.10' and record.id in scaffolds:
-            out.write(f">{record.id}_1\n{record.seq}\n")
-            out.write(f">{record.id}_2\n{record.seq}\n")
+    with gzip.open(args.reference, 'rt') as fasta_file:
+        for record in SeqIO.parse(fasta_file, 'fasta'):
+            if record.id != 'NC_000024.10' and record.id in scaffolds:
+                out.write(f">{record.id}_1\n{record.seq}\n")
+                out.write(f">{record.id}_2\n{record.seq}\n")
 
 # Create the male reference genome
 # Put two copies of the reference genome in the output file except for
 # the x chromosome and the y chromosome
 with open(f"{args.output}_male.fasta", 'w') as out:
-    for record in SeqIO.parse(args.reference, 'fasta'):
-        if record.id != 'NC_000023.11' and record.id != 'NC_000024.10' and record.id in scaffolds:
-            out.write(f">{record.id}_1\n{record.seq}\n")
-            out.write(f">{record.id}_2\n{record.seq}\n")
-        elif record.id == 'NC_000023.11':
-            out.write(f">{record.id}_1\n{record.seq}\n")
-        elif record.id == 'NC_000024.10':
-            out.write(f">{record.id}_2\n{record.seq}\n")
+    with gzip.open(args.reference, 'rt') as fasta_file:
+        for record in SeqIO.parse(fasta_file, 'fasta'):
+            if record.id != 'NC_000023.11' and record.id != 'NC_000024.10' and record.id in scaffolds:
+                out.write(f">{record.id}_1\n{record.seq}\n")
+                out.write(f">{record.id}_2\n{record.seq}\n")
+            elif record.id == 'NC_000023.11':
+                out.write(f">{record.id}_1\n{record.seq}\n")
+            elif record.id == 'NC_000024.10':
+                out.write(f">{record.id}_2\n{record.seq}\n")
 
 


### PR DESCRIPTION
A pull request for the release v0.1.2. Please first review a pull request https://github.com/hanhntran/SCiMS-paper/pull/3
This release contains fixes for the correct work of `01_simulation/02_simulation_map_and_process_simulated_reads.smk` pipeline. 
Suggested changes: 
| # | Rule  | Description |
|---| ------------- | ------------- |
|1 | `index_ref_genomes` |  Moved this rule from `01_simulation/01_simulation_create_reads.smk` to the `01_simulation/02_simulation_map_and_process_simulated_reads.smk` pipeline. The output of this rule is not needed for the pipeline 01, and consequently is not executed. As a result, the genome indexes are not generated, and pipeline 02 is failing. Moving this rule to the pipeline 02 ensures the generation of the index files, neccessary for the correct work of pipeline 02. |
|2 | `index_ref_genomes`, `map_simulated_reads` | Edited the basename of the index file in  `index_ref_genomes` rule to match the expected basename in the downstream rules. Additionally, changed the extension of the indexed genome outputs. |
|3 | `map_simulated_reads` | (optional) Increased the allocated memory for samtools files and increased the number of processes for bowtie2 and samtools commands to reduce the computation time of this rule from 15+ hours to ~6 hours. |
|4 | `.gitignore` | Updated `.gitignore` to prevent the generated files from uploading. |

**Full Changelog**: https://github.com/PollyTikhonova/SCiMS-paper/compare/v0.1.1...v0.1.2