### PR TITLE
scripts/calculate_rxry_script.py

### DIFF
--- a/scripts/calculate_rxry_script.py
+++ b/scripts/calculate_rxry_script.py
@@ -24,7 +24,7 @@ def calculate_Rx_Ry(idxstats_files, scaffold_ids, x_id, y_id, system):
     with open(scaffold_ids, 'r') as f:
         scaffold_ids = f.read().splitlines()
     for idxstats_file in idxstats_files:
-        sample_id = os.path.basename(idxstats_file).split('.')[0]
+        sample_id, ext = os.path.splitext(os.path.basename(idxstats_file))
         idxstats = pd.read_table(idxstats_file, header=None, index_col=0)
         idxstats = idxstats.loc[scaffold_ids]
 


### PR DESCRIPTION
This pull request contains fixes for the correct work of `01_simulation/05_simulation_rxry.sh` pipeline and downstream `scripts/figure2.py`. 

Suggested changes: 
| # | File  | Description |
|---| ------------- | ------------- |
|1 | `01_simulation/05_simulation_rxry.sh` |  Updated parsing of the sample names to include `.1000x`, since BeXY and SCiMS include this bit in the sample names. Otherwise, the merging of the table results produced by the rx_ry pipeline with SCiMS and BeXY results ends up in a null table, due to merging by sample name, and rx_ry sample names are technically different (lacking of`.1000x`). |

**Full Changelog**: https://github.com/PollyTikhonova/SCiMS-paper/compare/v0.0.1...v0.1.5-1