### PR TITLE
minor typos: 02_hmp/02_hmp_scims.sh

### DIFF
--- a/02_hmp/02_hmp_scims.sh
+++ b/02_hmp/02_hmp_scims.sh
@@ -3,11 +3,11 @@
 # Set directories consistent with Snakefile outputs
 IDXSTATS_DIR="./02_hmp/mapped_reads"
 OUTPUT_DIR="./02_hmp/results"
-SCAFFOLDS_FILE="./data/ref_genome/GRCh38_scaffold.txt"
+SCAFFOLDS_FILE="./data/ref_genome/GRCh38_scaffolds.txt"
 METADATA_FILE="./02_hmp/dbGap_metadata.txt"
 X_scaffold="NC_000023.11"
 Y_scaffold="NC_000024.10"
-id_colummn="Run"
+id_column="Run"
 
 # Run SCiMS
 scims \


### PR DESCRIPTION
This PR contains fixes for the correct work of `02_hmp/02_hmp_scims.sh` pipeline. 

Suggested changes: 
| # | File  | Description |
|---| ------------- | ------------- |
|1 | `02_hmp/02_hmp_scims.sh` |  Minor typos. |

**Full Changelog**: https://github.com/PollyTikhonova/SCiMS-paper/compare/v.0.0.2...v0.2.2