### PR TITLE
typos 02_hmp/04_hmp_bexy.sh

### DIFF
--- a/02_hmp/04_hmp_bexy.sh
+++ b/02_hmp/04_hmp_bexy.sh
@@ -5,11 +5,11 @@ OUTPUT_DIR="./02_hmp/results/bexy"
 
 mkdir -p ${OUTPUT_DIR}
 
-ls ${IDXSTATS_DIR}/*.1000x.idxstats > ${OUTPUT_DIR}/hmp_idxstats.txt
+ls ${IDXSTATS_DIR}/*.idxstats > ${OUTPUT_DIR}/hmp_idxstats.txt
 
 scaffolds="data/ref_genome/GRCh38_scaffolds.txt"
 
 # run bexy
-infer  --idxstats ${OUTPUT_DIR}/hmp_idxstats.txt --keepScaffolds $scaffolds --maxNumThreads 16
+./tools/bexy/build/bexy infer  --idxstats ${OUTPUT_DIR}/hmp_idxstats.txt --keepScaffolds $scaffolds --maxNumThreads 16
 
 


### PR DESCRIPTION
This PR contains fixes for the correct work of `02_hmp/04_hmp_bexy.sh` in part 2: HMP

Suggested changes: 
| # | File  | Description |
|---| ------------- | ------------- |
|1 | `02_hmp/04_hmp_bexy.sh` |  Fixed listing of hmp files in `hmp_idxstats.txt` |
|2 | `02_hmp/04_hmp_bexy.sh` |  Added calling of `bexy` |

**Full Changelog**: https://github.com/PollyTikhonova/SCiMS-paper/compare/v.0.0.2...v0.2.4