### PR TITLE
04_chicken/01_chicken_data_processing.smk

### DIFF
--- a/04_chicken/01_chicken_data_processing.smk
+++ b/04_chicken/01_chicken_data_processing.smk
@@ -94,9 +94,39 @@ rule map_reads:
         samtools sort -o {output.bam}
         """
 
+rule add_read_groups:
+    """
+    Add read groups to the sorted BAM file. Read groups (RG) are required by Picard mark duplicates (next rule). 
+    Because these reads are simulated, I just made up some random values to satisfy the RG requirements.
+    """
+    input:
+        sorted_bam=f"{mapped_reads_dir}/{{sra}}.sorted.bam"
+    output:
+        rg_bam=f"{mapped_reads_dir}/{{sra}}.sorted.rg.bam"
+    params:
+        RGID="{sra}",
+        RGLB="lib1",
+        RGPL="illumina",
+        RGPU="unit1",
+        RGSM="{sra}"
+    conda:
+        f"{main_dir}/envs/picard.yaml"
+    shell:
+        """
+        picard AddOrReplaceReadGroups \
+            I={input.sorted_bam} \
+            O={output.rg_bam} \
+            RGID={params.RGID} \
+            RGLB={params.RGLB} \
+            RGPL={params.RGPL} \
+            RGPU={params.RGPU} \
+            RGSM={params.RGSM} \
+            CREATE_INDEX=true
+        """
+
 rule remove_duplicates:
     input:
-        bam = f"{mapped_reads_dir}/{{sra}}.sorted.bam"
+        bam = f"{mapped_reads_dir}/{{sra}}.sorted.rg.bam"
     output:
         bam = f"{mapped_reads_dir}/{{sra}}.rmdup.bam",
         metrics = f"{mapped_reads_dir}/{{sra}}.metrics.txt"


### PR DESCRIPTION
This PR contains fixes for the correct work of `04_chicken/01_chicken_data_processing.smk`

Suggested changes: 
| # | File  | Description |
|---| ------------- | ------------- |
|1 | `04_chicken/01_chicken_data_processing.smk` |   |
|1.1 | |  [Same as in HMP] Renamed reverse to reverse_, because reverse is apparently a reserved word. |
|1.2 |  |  [Same as in HMP] Updated the `rule index_ref_genome` expected output to match the expected `rule all: input`. Otherwise, the pipeline is not compiling, since no rule provides all some of the `rule all` expected files. |
|1.3 |  |  [Same as in HMP] Copypasted the add groups rule from HMP pipeline.|

**Full Changelog**: https://github.com/PollyTikhonova/SCiMS-paper/compare/v0.0.3...v0.4.1