### PR TITLE
04_chicken/04_chicken_bexy.sh

### DIFF
--- a/04_chicken/04_chicken_bexy.sh
+++ b/04_chicken/04_chicken_bexy.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
 IDXSTATS_DIR="./04_chicken/mapped_reads"
+OUTPUT_DIR="./04_chicken/results/bexy"
 
-ls ${IDXSTATS_DIR}/*.idxstats > chicken_idxstats.txt
+mkdir -p ${OUTPUT_DIR}
+
+ls ${IDXSTATS_DIR}/*.idxstats > ${OUTPUT_DIR}/chicken_idxstats.txt
 
 chicken_scaffolds="data/ref_genome/chicken_scaffolds.txt"
 
 # run bexy
-./tools/bexy/build/bexy infer  --idxstats chicken_idxstats.txt  --keepScaffolds $chicken_scaffolds --maxNumThreads 16
+./tools/bexy/build/bexy infer  --idxstats ${OUTPUT_DIR}/chicken_idxstats.txt  --keepScaffolds $chicken_scaffolds --maxNumThreads 16


### PR DESCRIPTION
This PR contains fixes for the correct work of `04_chicken/04_chicken_bexy.sh`

Suggested changes: 
| # | File  | Description |
|---| ------------- | ------------- |
|1 | `04_chicken/04_chicken_bexy.sh` |  Fixed listing of idxstat files in `chicken_idxstats.txt` |
|2 | `04_chicken/04_chicken_bexy.sh` |  Added calling of `bexy` |
|3 | `04_chicken/04_chicken_bexy.sh` |  Added an output path, store all bexy results in one folder |

**Full Changelog**: https://github.com/PollyTikhonova/SCiMS-paper/compare/v0.0.4...v0.4.4